### PR TITLE
Add Toprank to Tooling skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ This allows agents to stay fast and focused, while still executing tasks with re
 | [gitops-workflow](https://github.com/wshobson/agents/tree/main/plugins/kubernetes-operations/skills/gitops-workflow) | Implement GitOps workflows with ArgoCD and Flux for automated, declarative Kubernetes deployments with continuous reconciliation. Use when implementing GitOps practices, automating Kubernetes deployments, or setting up declarative infrastructure management. |
 | [gitlab-ci-patterns](https://github.com/wshobson/agents/tree/main/plugins/cicd-automation/skills/gitlab-ci-patterns) | Build GitLab CI/CD pipelines with multi-stage workflows, caching, and distributed runners for scalable automation. Use when implementing GitLab CI/CD, optimizing pipeline performance, or setting up automated testing and deployment. |
 | [git-advanced-workflows](https://github.com/wshobson/agents/tree/main/plugins/developer-essentials/skills/git-advanced-workflows) | Master advanced Git workflows including rebasing, cherry-picking, bisect, worktrees, and reflog to maintain clean history and recover from any situation. Use when managing complex Git histories, collaborating on feature branches, or troubleshooting repository issues. |
+| [toprank](https://github.com/nowork-studio/toprank) | Open-source MIT Claude Code plugin with 9 SEO and Google Ads skills. Connects Google Search Console, PageSpeed Insights, and the Google Ads API, and can ship fixes such as meta tag rewrites, JSON-LD schema generation, keyword bid adjustments, and CMS content pushes. |
 
 ---
 


### PR DESCRIPTION
## Summary
- add Toprank to `README.md` under `### Tooling`
- describe it as an open-source MIT Claude Code plugin with 9 SEO and Google Ads skills
- note its Google Search Console, PageSpeed Insights, and Google Ads API integrations plus the workflow fixes it can ship

## Why it fits
Toprank is an actively maintained MIT-licensed Claude Code plugin with 100+ GitHub stars that packages practical developer workflow skills for SEO and Google Ads operations.

This repository does not currently have a `Developer Productivity Tools` section, so `### Tooling` is the closest existing category because it already groups workflow-oriented agent skills and developer automation entries.

## File updated
- `README.md` in the `### Tooling` section