### PR TITLE
Add before-you-build-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ This allows agents to stay fast and focused, while still executing tasks with re
 
 | Skill | Description |
 |-----------|-----------|
+| [before-you-build-skill](https://github.com/bin1874/before-you-build-skill) | Review product and feature risk before agents start building. |
 | [chatcrystal-debug-recall](https://github.com/ZengLiangYi/ChatCrystal/tree/main/skills/chatcrystal-debug-recall) | Recall prior ChatCrystal debugging memories for failing tests, compiler errors, runtime exceptions, dependency issues, and regressions before proposing fixes. |
 | [chatcrystal-task-recall](https://github.com/ZengLiangYi/ChatCrystal/tree/main/skills/chatcrystal-task-recall) | Recall project-first and global-supplement ChatCrystal memories before substantive implementation, refactoring, migration, configuration, investigation, or optimization work. |
 | [chatcrystal-task-writeback](https://github.com/ZengLiangYi/ChatCrystal/tree/main/skills/chatcrystal-task-writeback) | Persist reusable task memories through ChatCrystal Core writeback, or emit structured memory candidates when Core is unavailable. |


### PR DESCRIPTION
Adds Before You Build Skill to the Tooling section.\n\nWhy it fits:\n- It is a public agent skill repository with SKILL.md, references, examples, and install notes.\n- It helps coding agents review product and feature risk before implementation.\n- It is compatible with Codex, Claude Code, Cursor, OpenCode, OpenClaw, and similar tools as a local skill or custom instruction package.\n\nProject: https://github.com/bin1874/before-you-build-skill