### PR TITLE
Add CheckYourself and Web Typography skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ This allows agents to stay fast and focused, while still executing tasks with re
 | [ml-pipeline-workflow](https://github.com/wshobson/agents/tree/main/plugins/machine-learning-ops/skills/ml-pipeline-workflow) | Build end-to-end MLOps pipelines from data preparation through model training, validation, and production deployment. Use when creating ML pipelines, implementing MLOps practices, or automating model training and deployment workflows. |
 | [sequenzy-email-marketing](https://github.com/Sequenzy/skills/tree/main/skills/sequenzy-email-marketing) | Operate Sequenzy email marketing and transactional/product email workflows from AI agents, including subscribers, campaigns, sequences, templates, sending, and usage checks. |
 | [istio-traffic-management](https://github.com/wshobson/agents/tree/main/plugins/cloud-infrastructure/skills/istio-traffic-management) | Configure Istio traffic management including routing, load balancing, circuit breakers, and canary deployments. Use when implementing service mesh traffic policies, progressive delivery, or resilience patterns. |
+| [web-typography-skill](https://github.com/simongonzalezdc/web-typography-skill) | Web typography workflow for readable, accessible front-end text. |
 
 ---
 
@@ -121,6 +122,7 @@ This allows agents to stay fast and focused, while still executing tasks with re
 | [tdd-workflow](https://github.com/cfrs2005/claude-init/tree/main/templates/.claude/skills/tdd-workflow) | Use this skill when writing new features, fixing bugs, or refactoring code. Enforce test-driven development (TDD), including unit tests, integration tests, and end-to-end (E2E) tests, ensuring test coverage exceeds 80%. |
 | [oping](https://github.com/bfly123/claude_code_bridge/tree/main/codex_skills/oping) | Test connectivity with OpenCode (shorthand: oc) using the oping CLI. Use when the user explicitly asks to check OpenCode/oc status or connectivity (e.g., “oc ping”, “oc is it alive?”, “is OpenCode connected?”), or when troubleshooting cases where OpenCode is not responding. |
 | [joedevflow](https://github.com/JoeCardoso13/joedevflow) | TDD-oriented workflow skill for coding agents with explicit design, red-test, implementation, and debug phases plus `HANDOFF.md` context handoffs. |
+| [checkyourself](https://github.com/KyaniteLabs/checkyourself/tree/main/skills/checkyourself) | Production-readiness diagnostics and guided remediation for AI-built apps. |
 
 ---
 


### PR DESCRIPTION
Adds two Agent Skill entries:

- Web Typography Skill under Frontend Development
- CheckYourself under Testing & QA

Verification:
- Existing README pre-commit checks passed

Note: README references CONTRIBUTING.md, but that file is not present in the repository; README also says new Agent Skill suggestions are welcome by PR.