### PR TITLE
Add sleek-design-mobile-apps skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ This allows agents to stay fast and focused, while still executing tasks with re
 | [single-cell-cellphonedb-communication-mapping](https://github.com/Starlitnightly/omicverse/tree/master/.claude/skills/single-cellphone-db) | Run omicverse's CellPhoneDB v5 wrapper on annotated single-cell data to infer ligand-receptor networks and produce CellChat-style visualisations. |
 | [effect-patterns-platform-getting-started](https://github.com/PaulJPhilp/EffectPatterns/tree/main/config/.claude-plugin/plugins/effect-patterns/skills/effect-patterns-platform-getting-started) | Effect-TS patterns for Platform Getting Started. Use when working with platform getting started in Effect-TS applications. |
 | [android-kotlin](https://github.com/alinaqi/claude-bootstrap/tree/main/skills/android-kotlin) | Android Kotlin development with Coroutines, Jetpack Compose, Hilt, and MockK testing |
-| [sleek-design-mobile-apps](https://github.com/sleekdotdesign/agent-skills/tree/main) | Design mobile apps with [sleek.design](https://sleek.design) via a REST API. Use when the user wants to design a mobile app, create screens, build UI, or interact with their Sleek projects. Covers high-level requests ("design an app that does X") and specific ones ("list my projects", "create a new project", "screenshot that screen"). |
+| [sleek-design-mobile-apps](https://github.com/sleekdotdesign/agent-skills/tree/main/skills/design-mobile-apps) | Design mobile apps with [sleek.design](https://sleek.design) via a REST API. Use when the user wants to design a mobile app, create screens, build UI, or interact with their Sleek projects. Covers high-level requests ("design an app that does X") and specific ones ("list my projects", "create a new project", "screenshot that screen"). |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ This allows agents to stay fast and focused, while still executing tasks with re
 | [single-cell-cellphonedb-communication-mapping](https://github.com/Starlitnightly/omicverse/tree/master/.claude/skills/single-cellphone-db) | Run omicverse's CellPhoneDB v5 wrapper on annotated single-cell data to infer ligand-receptor networks and produce CellChat-style visualisations. |
 | [effect-patterns-platform-getting-started](https://github.com/PaulJPhilp/EffectPatterns/tree/main/config/.claude-plugin/plugins/effect-patterns/skills/effect-patterns-platform-getting-started) | Effect-TS patterns for Platform Getting Started. Use when working with platform getting started in Effect-TS applications. |
 | [android-kotlin](https://github.com/alinaqi/claude-bootstrap/tree/main/skills/android-kotlin) | Android Kotlin development with Coroutines, Jetpack Compose, Hilt, and MockK testing |
-| [sleek-design-mobile-apps](https://github.com/sleekdotdesign/agent-skills/tree/main/skills/design-mobile-apps) | Design mobile apps with [sleek.design](https://sleek.design) via a REST API. Use when the user wants to design a mobile app, create screens, build UI, or interact with their Sleek projects. Covers high-level requests ("design an app that does X") and specific ones ("list my projects", "create a new project", "screenshot that screen"). |
+| [sleek-design-mobile-apps](https://github.com/sleekdotdesign/agent-skills/tree/main) | Design mobile apps with [sleek.design](https://sleek.design) via a REST API. Use when the user wants to design a mobile app, create screens, build UI, or interact with their Sleek projects. Covers high-level requests ("design an app that does X") and specific ones ("list my projects", "create a new project", "screenshot that screen"). |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ This allows agents to stay fast and focused, while still executing tasks with re
 | [single-cell-cellphonedb-communication-mapping](https://github.com/Starlitnightly/omicverse/tree/master/.claude/skills/single-cellphone-db) | Run omicverse's CellPhoneDB v5 wrapper on annotated single-cell data to infer ligand-receptor networks and produce CellChat-style visualisations. |
 | [effect-patterns-platform-getting-started](https://github.com/PaulJPhilp/EffectPatterns/tree/main/config/.claude-plugin/plugins/effect-patterns/skills/effect-patterns-platform-getting-started) | Effect-TS patterns for Platform Getting Started. Use when working with platform getting started in Effect-TS applications. |
 | [android-kotlin](https://github.com/alinaqi/claude-bootstrap/tree/main/skills/android-kotlin) | Android Kotlin development with Coroutines, Jetpack Compose, Hilt, and MockK testing |
+| [sleek-design-mobile-apps](https://github.com/sleekdotdesign/agent-skills/tree/main/skills/design-mobile-apps) | Design mobile apps with [sleek.design](https://sleek.design) via a REST API. Use when the user wants to design a mobile app, create screens, build UI, or interact with their Sleek projects. Covers high-level requests ("design an app that does X") and specific ones ("list my projects", "create a new project", "screenshot that screen"). |
 
 ---
 


### PR DESCRIPTION
Adds the [sleek-design-mobile-apps](https://github.com/sleekdotdesign/agent-skills/tree/main/skills/design-mobile-apps) skill under **Mobile Development**.

### About the skill
[sleek.design](https://sleek.design) is an AI-powered mobile app design tool. The skill teaches agents how to interact with Sleek's REST API (`/api/v1/*`) to create projects, describe what they want built in plain language, and get back rendered screens — covering both high-level requests ("design an app that does X") and specific ones ("list my projects", "create a new project", "screenshot that screen").

### Entry added
| Skill | Description |
|-----------|-----------|
| [sleek-design-mobile-apps](https://github.com/sleekdotdesign/agent-skills/tree/main/skills/design-mobile-apps) | Design mobile apps with [sleek.design](https://sleek.design) via a REST API. Use when the user wants to design a mobile app, create screens, build UI, or interact with their Sleek projects. Covers high-level requests ("design an app that does X") and specific ones ("list my projects", "create a new project", "screenshot that screen"). |

Source SKILL.md: https://github.com/sleekdotdesign/agent-skills/blob/main/skills/design-mobile-apps/SKILL.md