### PR TITLE
Add ABVX Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ This allows agents to stay fast and focused, while still executing tasks with re
 | [toprank](https://github.com/nowork-studio/toprank) | Open-source MIT Claude Code plugin with 9 SEO and Google Ads skills. Connects Google Search Console, PageSpeed Insights, and the Google Ads API, and can ship fixes such as meta tag rewrites, JSON-LD schema generation, keyword bid adjustments, and CMS content pushes. |
 | [swarmclaw](https://github.com/swarmclawai/swarmclaw/tree/main/skills/swarmclaw) | Operate SwarmClaw's self-hosted multi-agent runtime, skills, delegation, provider routing, schedules, and MCP workflows. |
 | [swarmvault](https://github.com/swarmclawai/swarmvault/tree/main/skills/swarmvault) | Build local-first knowledge vaults, graph-backed context packs, durable research outputs, and MCP-accessible project memory. |
+| [abvx-agent-skills](https://github.com/markoblogo/abvx-agent-skills) | Small, auditable coding-agent skillpack for smaller diffs, evidence-led debugging, token-efficient execution, browser verification, and validation-gated `SKILL.md` workflows. |
 
 ---
 


### PR DESCRIPTION
## Summary
- add `abvx-agent-skills` to the Tooling section

## Why
ABVX Agent Skills is a strong fit for this list's coding-agent audience. The pack focuses on smaller diffs, evidence-led debugging, token-efficient execution, browser verification, and reviewable validation-gated `SKILL.md` workflows.
