### PR TITLE
Add ax-extract-workflow skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ This allows agents to stay fast and focused, while still executing tasks with re
 | Skill | Description |
 |-----------|-----------|
 | [agenttrace-session-audit](https://github.com/luoyuctl/agenttrace/tree/master/skills/agenttrace-session-audit) | Audit local AI coding-agent sessions for cost, tokens, tool failures, latency, anomalies, health scores, diffs, and CI gate readiness across Claude Code, Codex CLI, Gemini CLI, Aider, Cursor, and similar tools. |
+| [ax-extract-workflow](https://github.com/Necmttn/ax/tree/main/skills/ax-extract-workflow) | Reconstruct the skill sequence, decisions, and handoffs behind a shipped feature from local ax session history. |
 | [risk-metrics-calculation](https://github.com/wshobson/agents/tree/main/plugins/quantitative-trading/skills/risk-metrics-calculation) | Calculate portfolio risk metrics including VaR, CVaR, Sharpe, Sortino, and drawdown analysis. Use when measuring portfolio risk, implementing risk limits, or building risk monitoring systems. |
 | [domain-cloud-native](https://github.com/rustfs/rustfs/tree/main/.claude/skills/domain-cloud-native) | Use when building cloud-native applications. Keywords: Kubernetes, k8s, Docker, containers, gRPC, Tonic, microservices, service mesh, observability, tracing, metrics, health checks, cloud, deployment, cloud-native, microservices, containers. |
 | [appinsights-instrumentation](https://github.com/github/awesome-copilot/tree/main/skills/appinsights-instrumentation) | Instrument a webapp to send useful telemetry data to Azure App Insights |


### PR DESCRIPTION
## Summary
Add ax-extract-workflow to the Observability skills table.

## Why
The skill reconstructs shipped-feature workflows from local ax session history, including skill sequence, decisions, and handoffs.

## Checks
- git diff --check
- focused markdownlint check for the inserted README row
- verified https://github.com/Necmttn/ax/tree/main/skills/ax-extract-workflow

---

_Generated with [ax](https://github.com/Necmttn/ax)._

