### PR TITLE
Add skillreaper — transcript-based context pruning CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ This allows agents to stay fast and focused, while still executing tasks with re
 | [NotFair](https://github.com/nowork-studio/NotFair) | Open-source Claude Code skills for SEO, GEO, Google Ads, and Meta Ads. Skill areas: [seo/](https://github.com/nowork-studio/NotFair/tree/main/seo) (site analysis, keyword research, meta tags, schema markup, GEO, content writing), [google-ads/](https://github.com/nowork-studio/NotFair/tree/main/google-ads) (audits, wasted-spend detection, keyword & bid management), [meta-ads/](https://github.com/nowork-studio/NotFair/tree/main/meta-ads) (ROAS, creative fatigue, audience overlap). Connects to live data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP. |
 | [swarmclaw](https://github.com/swarmclawai/swarmclaw/tree/main/skills/swarmclaw) | Operate SwarmClaw's self-hosted multi-agent runtime, skills, delegation, provider routing, schedules, and MCP workflows. |
 | [swarmvault](https://github.com/swarmclawai/swarmvault/tree/main/skills/swarmvault) | Build local-first knowledge vaults, graph-backed context packs, durable research outputs, and MCP-accessible project memory. |
+| [skillreaper](https://github.com/thousandflowers/skillreaper) | Reads real session transcripts to find skills, MCP servers, and agents that were loaded but never fired, then safely quarantines them. Supports Claude Code, Codex, Hermes, OpenCode, Cursor, and OpenClaw. Zero telemetry, single static Go binary, Homebrew and npm. MIT. |
 
 ---
 


### PR DESCRIPTION
Adds [**skillreaper**](https://github.com/thousandflowers/skillreaper) to the **Tooling** table.

**What it does:** reads real session transcripts to find skills, MCP servers, and agents that were loaded into context but never fired, then safely quarantines them.

**Why it fits Tooling:** it's a CLI for the agent-skills ecosystem, in the same family as `agent-skill-groups` (skill group/profile manager) and the other Claude Code plugins/CLIs already in this section (e.g. `unslop`). Supports Claude Code, Codex, Hermes, OpenCode, Cursor, and OpenClaw. Zero telemetry, single static Go binary, Homebrew and npm, MIT.

Only README.md changed (one table row added).