### PR TITLE
Add skills-janitor to Tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ This allows agents to stay fast and focused, while still executing tasks with re
 | [swarmclaw](https://github.com/swarmclawai/swarmclaw/tree/main/skills/swarmclaw) | Operate SwarmClaw's self-hosted multi-agent runtime, skills, delegation, provider routing, schedules, and MCP workflows. |
 | [swarmvault](https://github.com/swarmclawai/swarmvault/tree/main/skills/swarmvault) | Build local-first knowledge vaults, graph-backed context packs, durable research outputs, and MCP-accessible project memory. |
 | [skillreaper](https://github.com/thousandflowers/skillreaper) | Reads real session transcripts to find skills, MCP servers, and agents that were loaded but never fired, then safely quarantines them. Supports Claude Code, Codex, Hermes, OpenCode, Cursor, and OpenClaw. Zero telemetry, single static Go binary, Homebrew and npm. MIT. |
+| [skills-janitor](https://github.com/khendzel/skills-janitor) | Audits every installed skill across Claude Code and Codex scopes (user, project, plugin-installed), surfaces duplicates and broken skills, splits token cost into always-loaded descriptions vs on-demand bodies, tracks usage, and prunes unused skills via a swipe keep/delete/skip TUI. Zero dependencies, MIT. |
 
 ---
 


### PR DESCRIPTION
Adds [skills-janitor](https://github.com/khendzel/skills-janitor) to the **Tooling** table.

**What it does:** audits every installed skill across Claude Code and Codex scopes (user, project, and plugin-installed), surfaces duplicates and broken skills, splits token cost into always-loaded descriptions vs on-demand bodies, tracks which skills actually get used, and prunes unused ones via a swipe keep/delete/skip TUI. Zero dependencies, MIT.

**Why it fits Tooling:** it's a skill-management tool for the agent-skills ecosystem, in the same family as `skillreaper` and `agent-skill-groups` already in this section.

Only README.md changed (one table row added).