### PR TITLE
Add PickySteve — local skill router with fail-closed injection gating

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ This allows agents to stay fast and focused, while still executing tasks with re
 | [swarmclaw](https://github.com/swarmclawai/swarmclaw/tree/main/skills/swarmclaw) | Operate SwarmClaw's self-hosted multi-agent runtime, skills, delegation, provider routing, schedules, and MCP workflows. |
 | [swarmvault](https://github.com/swarmclawai/swarmvault/tree/main/skills/swarmvault) | Build local-first knowledge vaults, graph-backed context packs, durable research outputs, and MCP-accessible project memory. |
 | [skillreaper](https://github.com/thousandflowers/skillreaper) | Reads real session transcripts to find skills, MCP servers, and agents that were loaded but never fired, then safely quarantines them. Supports Claude Code, Codex, Hermes, OpenCode, Cursor, and OpenClaw. Zero telemetry, single static Go binary, Homebrew and npm. MIT. |
+| [PickySteve](https://github.com/KernelLord/pickysteve) | Local skill router and context picker for coding agents: hybrid retrieval (BM25 + embeddings, RRF-fused) with cross-encoder rerank and an LLM judge routes each prompt to the right skill, then assembles a minimal nonce-boundaried context bundle. Fail-closed prompt-injection gate scans both the request and every retrieved document. Runs offline on local Ollama by default; ships an MCP server and an OpenAI-compatible proxy with one-command installers for 18 coding agents (Claude Code, Codex, Cursor, Cline, and others). MIT. |
 
 ---
 


### PR DESCRIPTION
Adds one row to the Tooling table, next to skillreaper.

PickySteve routes each coding-agent prompt to the right skill (hybrid BM25+embedding retrieval, cross-encoder rerank, LLM judge) and assembles a minimal nonce-boundaried context bundle; a fail-closed ONNX prompt-injection gate scans both the request and every retrieved document. Local-first, MIT.

Disclosure: I am the project author; this PR was prepared by Claude (agent) on my behalf.