### PR TITLE
Add markstream-install skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ This allows agents to stay fast and focused, while still executing tasks with re
 | [sequenzy-email-marketing](https://github.com/Sequenzy/skills/tree/main/skills/sequenzy-email-marketing) | Operate Sequenzy email marketing and transactional/product email workflows from AI agents, including subscribers, campaigns, sequences, templates, sending, and usage checks. |
 | [istio-traffic-management](https://github.com/wshobson/agents/tree/main/plugins/cloud-infrastructure/skills/istio-traffic-management) | Configure Istio traffic management including routing, load balancing, circuit breakers, and canary deployments. Use when implementing service mesh traffic policies, progressive delivery, or resilience patterns. |
 | [web-typography-skill](https://github.com/simongonzalezdc/web-typography-skill) | Web typography workflow for readable, accessible front-end text. |
+| [markstream-install](https://github.com/Simon-He95/markstream-vue/tree/main/.agents/skills/markstream-install) | Install and configure streaming Markdown renderers for Vue, React, Svelte, Angular, Nuxt, Next.js, and Vue 2, including optional peers, CSS order, SSR boundaries, and streaming state. |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds the official `markstream-install` skill to Frontend Development.

The skill gives coding agents a practical workflow for selecting and configuring Markstream's streaming Markdown renderer across Vue, React, Svelte, Angular, Nuxt, Next.js, and Vue 2. It covers minimal optional peers, CSS order, SSR boundaries, streaming completion, and safe defaults.

## Checks

- Searched the repository and confirmed there is no existing Markstream entry.
- Linked directly to the public `SKILL.md` directory in the upstream project.
- Confirmed the link returns HTTP 200.
- Added one table row only.
- `git diff --check` passes.

Thank you for maintaining this curated list.
