### PR TITLE
Add superpowers-lite to Tooling skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ This allows agents to stay fast and focused, while still executing tasks with re
 | [swarmclaw](https://github.com/swarmclawai/swarmclaw/tree/main/skills/swarmclaw) | Operate SwarmClaw's self-hosted multi-agent runtime, skills, delegation, provider routing, schedules, and MCP workflows. |
 | [swarmvault](https://github.com/swarmclawai/swarmvault/tree/main/skills/swarmvault) | Build local-first knowledge vaults, graph-backed context packs, durable research outputs, and MCP-accessible project memory. |
 | [skillreaper](https://github.com/thousandflowers/skillreaper) | Reads real session transcripts to find skills, MCP servers, and agents that were loaded but never fired, then safely quarantines them. Supports Claude Code, Codex, Hermes, OpenCode, Cursor, and OpenClaw. Zero telemetry, single static Go binary, Homebrew and npm. MIT. |
+| [superpowers-lite](https://github.com/nanyumeng/superpowers-lite) | Unofficial, reversible skills overlay for obra/superpowers that keeps its skill names and engineering guardrails while making workflow orchestration proportional to task risk. |
 
 ---
 


### PR DESCRIPTION
## What changed

Added `superpowers-lite` to the **Tooling** skills table.

## Why it fits

Superpowers Lite is an unofficial skills overlay for `obra/superpowers`, based on upstream v6.1.1. It keeps the existing skill names and core engineering guardrails while making planning, delegation, review, and debugging proportional to task risk.

I maintain the listed project. It is not endorsed by Superpowers, OpenAI, or Anthropic. The project documents [reversible installation and rollback](https://nanyumeng.github.io/superpowers-lite/install/) and states its [evidence limitations](https://nanyumeng.github.io/superpowers-lite/evidence/).

## Checks

- Existing Markdown table format preserved
- Repository URL verified
- One README row changed; no other files modified
