### PR TITLE
Add wiki to Tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ This allows agents to stay fast and focused, while still executing tasks with re
 | [swarmclaw](https://github.com/swarmclawai/swarmclaw/tree/main/skills/swarmclaw) | Operate SwarmClaw's self-hosted multi-agent runtime, skills, delegation, provider routing, schedules, and MCP workflows. |
 | [swarmvault](https://github.com/swarmclawai/swarmvault/tree/main/skills/swarmvault) | Build local-first knowledge vaults, graph-backed context packs, durable research outputs, and MCP-accessible project memory. |
 | [skillreaper](https://github.com/thousandflowers/skillreaper) | Reads real session transcripts to find skills, MCP servers, and agents that were loaded but never fired, then safely quarantines them. Supports Claude Code, Codex, Hermes, OpenCode, Cursor, and OpenClaw. Zero telemetry, single static Go binary, Homebrew and npm. MIT. |
+| [wiki](https://github.com/plasma-ai/wiki/tree/main/wiki/skills/wiki) | Indexed knowledge bases with command-line tools for agents. |
 
 ---
 


### PR DESCRIPTION
## Summary

Add the [wiki skill](https://github.com/plasma-ai/wiki/tree/main/wiki/skills/wiki) to **Tooling**.

wiki combines an Agent Skill with a deterministic CLI for building and maintaining indexed Markdown knowledge bases. The entry follows the existing two-column Tooling format.

Disclosure: I'm affiliated with the project.