### PR TITLE
Add Banuba AI Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ This allows agents to stay fast and focused, while still executing tasks with re
 | [swarmclaw](https://github.com/swarmclawai/swarmclaw/tree/main/skills/swarmclaw) | Operate SwarmClaw's self-hosted multi-agent runtime, skills, delegation, provider routing, schedules, and MCP workflows. |
 | [swarmvault](https://github.com/swarmclawai/swarmvault/tree/main/skills/swarmvault) | Build local-first knowledge vaults, graph-backed context packs, durable research outputs, and MCP-accessible project memory. |
 | [skillreaper](https://github.com/thousandflowers/skillreaper) | Reads real session transcripts to find skills, MCP servers, and agents that were loaded but never fired, then safely quarantines them. Supports Claude Code, Codex, Hermes, OpenCode, Cursor, and OpenClaw. Zero telemetry, single static Go binary, Homebrew and npm. MIT. |
+| [banuba](https://github.com/Banuba/ai-skills) | Banuba Agent Skills enable creating apps with Banuba SDKs by using Claude Code, Codex, and Qwen Code.  |
 
 ---
 


### PR DESCRIPTION
Banuba Agent Skills let users create apps with Banuba SDKs (Face AR, Video Editor & Photo Editor) with an AI coding assistant: Claude Code, Codex, and Qwen. 

The skills contain the following components:

- **Documentation lookup** skills are local-first and can answer from bundled docs. Builder skills may access the network to fetch versioned LLM docs, clone official samples, and install platform dependencies.

- **Guided code generation** - a step-by-step walkthrough and explanation of SDK implementation

- **Autonomous scaffolding** - a builder agent that creates complete Face AR, Video Editor, or Photo Editor projects from scratch
