### PR TITLE
Add HTML Docs agent skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ This allows agents to stay fast and focused, while still executing tasks with re
 | [swarmclaw](https://github.com/swarmclawai/swarmclaw/tree/main/skills/swarmclaw) | Operate SwarmClaw's self-hosted multi-agent runtime, skills, delegation, provider routing, schedules, and MCP workflows. |
 | [swarmvault](https://github.com/swarmclawai/swarmvault/tree/main/skills/swarmvault) | Build local-first knowledge vaults, graph-backed context packs, durable research outputs, and MCP-accessible project memory. |
 | [skillreaper](https://github.com/thousandflowers/skillreaper) | Reads real session transcripts to find skills, MCP servers, and agents that were loaded but never fired, then safely quarantines them. Supports Claude Code, Codex, Hermes, OpenCode, Cursor, and OpenClaw. Zero telemetry, single static Go binary, Homebrew and npm. MIT. |
+| [html-docs](https://github.com/raunaqbn/html-docs-skill/tree/main/html-docs) | Turn folders, codebases, websites, PDFs, documents, or research topics into source-grounded collaborative HTML pages, narrated explainer videos, or complete courses. Supports Codex and Claude Code, includes an MCP server, and publishes shareable outputs to HTML Docs. |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds the HTML Docs skill to the Tooling section.

It gives Codex and Claude Code a source-grounded workflow for turning folders, codebases, websites, PDFs, documents, or research topics into collaborative HTML pages, narrated explainer videos, and courses. The linked folder contains the full `SKILL.md`; the repository includes examples, local tooling, an MCP server, and an MIT license.

- Skill: https://github.com/raunaqbn/html-docs-skill/tree/main/html-docs
- Guide: https://www.html-docs.com/agents
- Showcase: https://www.html-docs.com/showcase

Prepared with agent assistance and manually scoped to one documented skill entry.