### PR TITLE
Add apply-technical-concepts

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ This allows agents to stay fast and focused, while still executing tasks with re
 
 | Skill | Description |
 |-----------|-----------|
+| [apply-technical-concepts](https://github.com/velimir-jankovic/apply-technical-concepts/tree/main/skills/apply-technical-concepts) | Turn a technical video into a repository audit or tested implementation. Keeps transcript and frame evidence tied to exact code paths and runtime results. |
 | [before-you-build-skill](https://github.com/bin1874/before-you-build-skill) | Review product and feature risk before agents start building. |
 | [chatcrystal-debug-recall](https://github.com/ZengLiangYi/ChatCrystal/tree/main/skills/chatcrystal-debug-recall) | Recall prior ChatCrystal debugging memories for failing tests, compiler errors, runtime exceptions, dependency issues, and regressions before proposing fixes. |
 | [chatcrystal-task-recall](https://github.com/ZengLiangYi/ChatCrystal/tree/main/skills/chatcrystal-task-recall) | Recall project-first and global-supplement ChatCrystal memories before substantive implementation, refactoring, migration, configuration, investigation, or optimization work. |


### PR DESCRIPTION
Adds one entry to Tooling for a skill that turns technical talks into repository audits or tested implementations. It keeps timestamped transcript/frame evidence tied to concrete code and runtime checks.
The skill is MIT licensed, passes the Agent Skills reference validator, and has a runnable clean-room proof:
- Skill: https://github.com/velimir-jankovic/apply-technical-concepts
- Lab: https://world-rewind-lab.velimirj1.chatgpt.site
- Lab source: https://github.com/velimir-jankovic/world-rewind-lab