### PR TITLE
Add skill: Nolane-x/nolane-axiom

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ This allows agents to stay fast and focused, while still executing tasks with re
 | [oping](https://github.com/bfly123/claude_code_bridge/tree/main/codex_skills/oping) | Test connectivity with OpenCode (shorthand: oc) using the oping CLI. Use when the user explicitly asks to check OpenCode/oc status or connectivity (e.g., “oc ping”, “oc is it alive?”, “is OpenCode connected?”), or when troubleshooting cases where OpenCode is not responding. |
 | [joedevflow](https://github.com/JoeCardoso13/joedevflow) | TDD-oriented workflow skill for coding agents with explicit design, red-test, implementation, and debug phases plus `HANDOFF.md` context handoffs. |
 | [checkyourself](https://github.com/KyaniteLabs/checkyourself/tree/main/skills/checkyourself) | Production-readiness diagnostics and guided remediation for AI-built apps. |
+| [nolane-axiom](https://github.com/Nolane-x/Nolane-Axiom/tree/main/skills/nolane-axiom) | Proof-carrying AI-agent investigation with causal debugging, evidence provenance, scoped authority, integrity ledgers, proof bundles, and release-grade QA. |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds the 
olane-axiom orchestrator skill to Testing & QA.

## Verification

- Public SKILL.md: https://github.com/Nolane-x/Nolane-Axiom/tree/main/skills/nolane-axiom
- 32-skill suite with a transactional cross-runtime installer
- Public v5.0.0 release with deterministic ZIP/TAR.GZ artifacts
- 152 tests and green Windows/Linux CI

The entry links directly to the installable skill directory and keeps the table description concise.