### PR TITLE
Add qamap-pr-qa to Testing & QA

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ This allows agents to stay fast and focused, while still executing tasks with re
 | [oping](https://github.com/bfly123/claude_code_bridge/tree/main/codex_skills/oping) | Test connectivity with OpenCode (shorthand: oc) using the oping CLI. Use when the user explicitly asks to check OpenCode/oc status or connectivity (e.g., “oc ping”, “oc is it alive?”, “is OpenCode connected?”), or when troubleshooting cases where OpenCode is not responding. |
 | [joedevflow](https://github.com/JoeCardoso13/joedevflow) | TDD-oriented workflow skill for coding agents with explicit design, red-test, implementation, and debug phases plus `HANDOFF.md` context handoffs. |
 | [checkyourself](https://github.com/KyaniteLabs/checkyourself/tree/main/skills/checkyourself) | Production-readiness diagnostics and guided remediation for AI-built apps. |
+| [qamap-pr-qa](https://github.com/IvoryCanvas/qamap/tree/main/skills/qamap-pr-qa) | Local zero-LLM PR QA workflow. Maps commit and diff evidence to affected behavior, routes QA scenarios with exact source evidence, selects the repository's existing validation command, and drafts optional automation. Use when preparing, updating, or reviewing a pull request, or when asking what a change should prove before merge. |
 
 ---
 


### PR DESCRIPTION
Adds QAMap's `qamap-pr-qa` skill to Testing & QA.

QAMap is a local PR QA tool that reads commit and diff evidence and returns
the behavior a change affects and the proof it needs before merge. It makes
no LLM calls and uploads no source. The skill lives at `skills/qamap-pr-qa`
and is vendor-neutral (Claude Code and Codex plugin manifests included).

Repo: https://github.com/IvoryCanvas/qamap
License: MIT
