### PR TITLE
Add youtube-full skill to Tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ This allows agents to stay fast and focused, while still executing tasks with re
 | [swarmclaw](https://github.com/swarmclawai/swarmclaw/tree/main/skills/swarmclaw) | Operate SwarmClaw's self-hosted multi-agent runtime, skills, delegation, provider routing, schedules, and MCP workflows. |
 | [swarmvault](https://github.com/swarmclawai/swarmvault/tree/main/skills/swarmvault) | Build local-first knowledge vaults, graph-backed context packs, durable research outputs, and MCP-accessible project memory. |
 | [skillreaper](https://github.com/thousandflowers/skillreaper) | Reads real session transcripts to find skills, MCP servers, and agents that were loaded but never fired, then safely quarantines them. Supports Claude Code, Codex, Hermes, OpenCode, Cursor, and OpenClaw. Zero telemetry, single static Go binary, Homebrew and npm. MIT. |
+| [youtube-full](https://github.com/ZeroPointRepo/youtube-skills/tree/main/skills/youtube-full) | Get YouTube transcripts, search videos and channels, list channel uploads, and extract playlists without Google API quotas or OAuth, usable in Claude, ChatGPT, OpenClaw, Hermes Agent and other MCP clients or from your own software via the TranscriptAPI REST API. MIT. |
 
 ---
 


### PR DESCRIPTION
Adds one row to the **Tooling** table for `youtube-full`.

**What it is:** an agent skill that gets YouTube transcripts, searches videos and channels, lists channel uploads, and extracts playlists, without Google API quotas or OAuth. It runs in Claude, ChatGPT, OpenClaw, Hermes Agent and other MCP clients, and the same capabilities are callable from your own software over a REST API.

**Source:** https://github.com/ZeroPointRepo/youtube-skills (MIT, free and open source). `youtube-full` is one of the skills in that repo.

**Install:** `npx skills add ZeroPointRepo/youtube-skills --skill youtube-full`

**Disclosure:** I maintain the `youtube-skills` repo and the TranscriptAPI service behind it.

Format follows the existing Tooling table rows byte for byte (single `| [name](link) | description |` row appended to the end of the table). One line changed, nothing else touched.
